### PR TITLE
[e2e] Add pandas join test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,33 +3,22 @@
 # Requirements
 
 Requires Python 3.9+. Install python requirements using pip.
-```
-pip install -r requirements.txt
+
+```shell
+$ pip install -r requirements.txt
 ```
 
 # Build
 
-```
-cmake -GNinja -Bbuild \
-  -DCMAKE_C_COMPILER=clang \
-  -DCMAKE_CXX_COMPILER=clang++ \
-  -DLLVM_ENABLE_PROJECTS=mlir \
-  -DLLVM_EXTERNAL_PROJECTS=pandas-mlir \
-  -DLLVM_EXTERNAL_PANDAS_MLIR_SOURCE_DIR=`pwd` \
-  -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
-  -DLLVM_TARGETS_TO_BUILD=host \
-  external/llvm-project/llvm
-
-# Build pandas-mlir
-cmake --build build --target tools/pandas-mlir/all
+```shell
+$ ./cmake_configure.sh
 
 # Build everything
-cmake --build build
+$ cmake --build build
 
 # Run unit tests
-cmake --build build --target check-pandas-mlir
+$ cmake --build build --target check-pandas-mlir
 
 # Convert Pandas Python -> Pandas MLIR
-cd python/test; pytest -s
-
+$ cd python/test; pytest -s
 ```

--- a/cmake_configure.sh
+++ b/cmake_configure.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+  # -DCMAKE_C_COMPILER=clang \
+  # -DCMAKE_CXX_COMPILER=clang++ \
+# NOTE: We compile with gcc, but use `lld` because linkage is much
+# faster on binaries with large / lots symbols (e.g. llvm/mlir) with
+# `lld`.
+#  -DCMAKE_CXX_FLAGS="-fuse-ld=lld" \
+cmake -GNinja -Bbuild \
+  -DCMAKE_PREFIX_PATH="${CONDA_PREFIX}" \
+  -DLLVM_ENABLE_PROJECTS=mlir \
+  -DLLVM_ENABLE_LIBCXX=ON \
+  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+  -DLLVM_EXTERNAL_PROJECTS=pandas-mlir \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DLLVM_EXTERNAL_PANDAS_MLIR_SOURCE_DIR=`pwd` \
+  -DMLIR_ENABLE_BINDINGS_PYTHON=OFF \
+  -DLLVM_TARGETS_TO_BUILD=host \
+  external/llvm-project/llvm

--- a/e2e_testing/join.py
+++ b/e2e_testing/join.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import numpy as np
+import time
+import sys
+sys.path.append('../python')
+from pandas_exporter import export_pandas, annotate_pandas
+
+@export_pandas
+@annotate_pandas(
+    arg0 = {"type": "DataFrame",
+            "schema": {"a": "i32", "b": "i32"},
+            "indices": ["key", 1, "hello"],
+            "dims": [3, 2]},
+    arg1 = {"type": "DataFrame",
+            "schema": {"a": "i32", "b": "i32"},
+            "indices": ["key", 1, "hello"],
+            "dims": [3, 2]},
+)
+def compute(df0, df1):
+    """
+    This test function demonstrates how pandas-mlir can export functions
+    when provided with complete information about the input.
+
+    Args:
+        df (pd.DataFrame): DataFrame with no nullable types and
+        fixed size.
+
+    Returns:
+        A linear combination of the "a" column and "b" column.
+
+    """
+    # Perform an inner join on the 'a' column.
+    # Should return the original dataframe because we
+    return pd.merge(
+        df0["a"],
+        df1[["a", "b"]],
+        left_on="a",
+        right_on="a",
+        # If true, adds a _merge column with details
+        # about whether the row comes from left, right
+        # or both columns we are joining on.
+        indicator=False
+    )
+
+df = pd.DataFrame({"a": [1, 4, 9], "b": [0, 3, 2]})
+
+startTime = time.time()
+res = compute(df, df)
+endTime = time.time()
+print(res)
+print("Elapsed time (ms): " + str((endTime - startTime) * 1000))

--- a/python/test/test_ast.py
+++ b/python/test/test_ast.py
@@ -14,8 +14,20 @@ class MyVisitor(ast.NodeVisitor):
         ast.NodeVisitor.generic_visit(self, node)
 
 class TestCase:
-    def test_convert(self):
-        with open('../../e2e_testing/dataframe.py', 'r') as f:
+
+
+    @pytest.mark.parametrize(
+        "py_ast_path",
+        [
+            '../../e2e_testing/dataframe.py',
+            pytest.param(
+                '../../e2e_testing/join.py',
+                marks=pytest.mark.xfail(reason='need error checking'),
+            ),
+        ]
+    )
+    def test_convert(self, py_ast_path):
+        with open(py_ast_path, 'r') as f:
             input = f.read()
         tree = ast.parse(input)
         #for node in ast.walk(tree):
@@ -25,4 +37,5 @@ class TestCase:
         #v = MyVisitor()
         #v.visit(tree)
         #breakpoint()
+        # TODO: Error checking so that conversion
         pandas_mlir_converter.convert_to_mlir(tree)


### PR DESCRIPTION
This patch adds an example of performing a `join` operation using
`pd.DataFrame`s. To run this test:

```shell
$ cd python/test
$ pytest -s -k 'test_convert[../../e2e_testing/join.py]'
```

NOTE: This test currently passes when it shouldn't. The exit code is
0, but we output the error(s) below. As a result, this test is marked
as an `xfail` because I don't *think* this should work out of the box yet.

```text
test_ast.py error: empty block: expect at least a terminator
error: failed to run passes
```

We also add an explicit `cmake_configure.sh` script and update the
docs to make getting started a little easier.